### PR TITLE
Fix workflow to activate venv

### DIFF
--- a/.github/workflows/ytbot.yml
+++ b/.github/workflows/ytbot.yml
@@ -42,6 +42,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_CLIENT_SECRET: file://client_secret.json
         run: |
+          source venv/bin/activate
           python yt_shorts_bot.py
 
       - name: Commit history


### PR DESCRIPTION
## Summary
- activate virtual environment before running bot

## Testing
- `python -m py_compile yt_shorts_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_684ef2224b50832a8a7115909ce95637