### PR TITLE
Add requirements file and update docs

### DIFF
--- a/.github/workflows/ytbot.yml
+++ b/.github/workflows/ytbot.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install google-api-python-client google-auth google-auth-oauthlib openai moviepy pillow python-dotenv tqdm
+          pip install -r requirements.txt
 
       - name: Decode client secret
         run: |

--- a/README.md
+++ b/README.md
@@ -13,3 +13,12 @@ The bot requires the following secrets:
 ## History
 
 Each run writes a JSON file to `history/` with the upload information.
+
+## Installing dependencies
+
+Before running the bot locally you need Python 3.10+ and the packages listed in
+`requirements.txt`. Install them with:
+
+```bash
+pip install -r requirements.txt
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+google-api-python-client
+google-auth
+google-auth-oauthlib
+openai
+moviepy
+pillow
+python-dotenv
+tqdm


### PR DESCRIPTION
## Summary
- document how to install dependencies
- use a `requirements.txt` file to simplify installation
- update workflow to install from requirements

## Testing
- `python -m py_compile yt_shorts_bot.py`
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684ef56ce3c4832ab89f2b77e6c0ee43