### PR TITLE
Fix OpenAI calls and video zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The bot requires the following secrets:
 
 - `OPENAI_API_KEY` – OpenAI API key
 - `DEEPSEEK_API_KEY` – DeepSeek API key
-- `GOOGLE_CLIENT_SECRET_JSON` – contents of `client_secret.json` (JSON or base64)
+- `GOOGLE_CLIENT_SECRET` – `file://client_secret.json` or `base64://...`
 
 ## History
 


### PR DESCRIPTION
## Summary
- handle OpenAI with a client instance
- fix DALL·E image size and audio write
- replace non-existent `vfx.zoom_in` with a resize zoom effect
- correct env variable name in README

## Testing
- `python -m py_compile yt_shorts_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_684f0604b978832aaa7cd92887f5907f