### PR TITLE
Fix moviepy version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -23,3 +23,6 @@ Before running the bot locally you need Python 3.10+ and the packages listed in
 ```bash
 pip install -r requirements.txt
 ```
+
+`requirements.txt` pins `moviepy==1.0.3`, because newer versions can break the
+import used in the script.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ openai
 google-api-python-client
 google-auth
 google-auth-oauthlib
-moviepy              # версия фиксируется в workflow
+moviepy==1.0.3       # фиксированная версия для совместимости
 pillow
 python-dotenv
 tqdm

--- a/yt_shorts_bot.py
+++ b/yt_shorts_bot.py
@@ -51,6 +51,7 @@ try:
 except ModuleNotFoundError as e:
     print("[debug] failed to import moviepy:", e)
     subprocess.call([sys.executable, "-m", "pip", "list"])
+    print("[hint] try: pip install moviepy==1.0.3")
     raise
 from dotenv import load_dotenv
 from tqdm import tqdm


### PR DESCRIPTION
## Summary
- pin `moviepy` to version 1.0.3
- mention the pinned version in README
- show hint when moviepy import fails
- add `.gitignore`

## Testing
- `python -m py_compile yt_shorts_bot.py`
- `pip install -r requirements.txt` *(fails: tunnel connection 403)*

------
https://chatgpt.com/codex/tasks/task_e_684f088d149c832a986989d82eaaccf5